### PR TITLE
Feature/trades edit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ end
 
 group :test do
   gem 'shoulda-matchers', '~> 5.0'
+  gem 'rspec-sidekiq'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,9 @@ GEM
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
+    rspec-sidekiq (3.1.0)
+      rspec-core (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
     rspec-support (3.11.0)
     rubocop (1.26.0)
       parallel (~> 1.10)
@@ -268,6 +271,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.7)
   rspec-rails (~> 4.1.0)
+  rspec-sidekiq
   rubocop
   rubocop-performance
   rubocop-rails

--- a/app/controllers/trades_controller.rb
+++ b/app/controllers/trades_controller.rb
@@ -15,6 +15,18 @@ class TradesController < ApplicationController
     @trade = Trade.find(params[:id])
   end
 
+  def edit
+    @trade = Trade.find(params[:id])
+  end
+
+  def update
+    TradeUpdater.call(trade_id: params[:id], trade_params: trade_params)
+
+    flash[:alert] = 'Trade was successfully updated.'
+
+    redirect_to trades_path
+  end
+
   def create
     TradeCreator.call(trade_params: trade_params)
 

--- a/app/controllers/trades_controller.rb
+++ b/app/controllers/trades_controller.rb
@@ -1,4 +1,5 @@
 class TradesController < ApplicationController
+  before_action :set_trade, only: [:show, :edit, :update]
   layout 'base'
 
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
@@ -12,15 +13,13 @@ class TradesController < ApplicationController
   end
 
   def show
-    @trade = Trade.find(params[:id])
   end
 
   def edit
-    @trade = Trade.find(params[:id])
   end
 
   def update
-    TradeUpdater.call(trade_id: params[:id], trade_params: trade_params)
+    TradeUpdater.call(trade_id: @trade.id, trade_params: trade_params)
 
     flash[:alert] = 'Trade was successfully updated.'
 
@@ -44,5 +43,9 @@ class TradesController < ApplicationController
       flash[:alert] = 'Trade not found'
 
       redirect_to trades_path
+    end
+
+    def set_trade
+      @trade = Trade.find(params[:id])
     end
 end

--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -12,6 +12,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  account_id :integer          not null
+#  job_id     :string
 #
 # Foreign Keys
 #

--- a/app/services/trade_sanitizer.rb
+++ b/app/services/trade_sanitizer.rb
@@ -1,0 +1,25 @@
+class TradeSanitizer
+  include Interactor
+
+  delegate :trade_params, to: :context
+
+  def self.call(trade_params:)
+    super
+  end
+
+  def call
+    enforce_timestamp_integer
+    enforce_symbol_upcase
+  end
+
+  private
+    def enforce_timestamp_integer
+      if trade_params[:timestamp].is_a?(String) && trade_params[:timestamp].present?
+        trade_params[:timestamp] = trade_params[:timestamp].to_datetime.to_i
+      end
+    end
+
+    def enforce_symbol_upcase
+      trade_params[:symbol] = trade_params[:symbol].upcase if trade_params[:symbol].present?
+    end
+end

--- a/app/services/trade_updater.rb
+++ b/app/services/trade_updater.rb
@@ -1,0 +1,47 @@
+class TradeUpdater
+  include Interactor
+
+  delegate :trade, to: :context
+  delegate :trade_params, to: :context
+
+  before do
+    raise ArgumentError, 'Missing trade_id' unless context.trade_id.present?
+
+    context.trade ||= Trade.find(context.trade_id)
+  end
+
+  def self.call(trade_id:, trade_params:)
+    super
+  end
+
+  def call
+    remove_scheduled_job if trade.job_id.present?
+    update
+    process if trade.persisted?
+  end
+
+  private
+    def remove_scheduled_job
+      Sidekiq::ScheduledSet.new.delete_by_jid(trade.timestamp, trade.job_id)
+    end
+
+    def update
+      params = TradeSanitizer.call(trade_params: trade_params).trade_params
+      trade.update!(params)
+    rescue ActiveRecord::NotNullViolation, ActiveRecord::RecordInvalid
+      context.fail!
+    end
+
+    def schedule
+      job_id = ScheduleTradeJob.perform_at(trade.timestamp, trade.id)
+      trade.update(job_id: job_id)
+    end
+
+    def process
+      if trade.timestamp >= Time.now.to_i
+        schedule
+      else
+        Trade::Run.call(trade_id: trade.id)
+      end
+    end
+end

--- a/app/views/trades/edit.html.erb
+++ b/app/views/trades/edit.html.erb
@@ -1,0 +1,49 @@
+<div class="my-auto mx-auto min-h-screen">
+  <div class="text-gray-600 body-font">
+    <div class="container px-5 py-24 mx-auto flex flex-wrap items-center">
+      <div class="lg:w-full md:w-1/2 bg-gray-100 rounded-lg p-8 flex flex-col md:ml-auto w-full mt-10 md:mt-0">
+        <%= form_with(model: @trade, url: trade_path(@trade), method: :patch) do |f| %>
+          <%= render "users/shared/error_messages", resource: @trade %>
+          <h2 class="text-gray-900 text-lg font-medium title-font mb-5">Trade <%= @trade.id %></h2>
+          <div class="relative mb-4">
+            <label for="trade[symbol]" class="leading-7 text-sm text-gray-600">Symbol</label>
+            <input type="text" required id="symbol" value="<%= @trade.symbol %>" name="trade[symbol]" class="uppercase w-full rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+          </div>
+          <div class="relative mb-4">
+            <label for="trade[account_id]" class="leading-7 text-sm text-gray-600">Bank Account</label>
+            <select required name='trade[account_id]' class="form-select appearance-none block w-full px-3 py-1.5 text-base font-normal text-gray-700 bg-white bg-clip-padding bg-no-repeat border border-solid border-gray-300 rounded transition ease-in-out m-0
+                             focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none" aria-label="Select you Bank Account">
+              <% current_user.bank_accounts.each do |bank_account| %>
+                <option <%= @trade.account_id == bank_account.id ? 'selected' : '' %>  value="<%= bank_account.id %>"><%= bank_account.id %></option>
+              <% end %>
+            </select>
+          </div>
+          <div class="relative mb-4">
+            <label for="trade[shares]" class="leading-7 text-sm text-gray-600">Shares</label>
+            <input type="number" min='1' value='<%= @trade.shares %>' max='100' required id="shares" name="trade[shares]" class="uppercase w-full rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+          </div>
+          <div class="relative mb-4">
+            <label for="trade[trade_type]" class="leading-7 text-sm text-gray-600">Trade Type</label>
+            <select required name='trade[trade_type]' class="form-select appearance-none block w-full px-3 py-1.5 text-base font-normal text-gray-700 bg-white bg-clip-padding bg-no-repeat border border-solid border-gray-300 rounded transition ease-in-out m-0
+                             focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none" aria-label="Select you Bank Account">
+              <%= TradeType.all.each do |trade_type| %>
+                <option <%= trade_type.name == @trade.trade_type ? 'selected' : '' %> value="<%= trade_type.name %>"><%= trade_type.name %></option>
+              <% end %>
+              </select>
+            </div>
+            <div class="relative mb-4">
+              <label for="trade[price]" class="leading-7 text-sm text-gray-600">Price</label>
+              <input type="number" min='1' value='<%= @trade.price %>' required id="price" name="trade[price]" class="uppercase w-full rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+            </div>
+            <div class="relative mb-4">
+              <label for="trade[timestamp]" class="leading-7 text-sm text-gray-600">Process at</label>
+              <%= f.datetime_field :timestamp, value: Time.at(f.object.timestamp).strftime('%Y-%m-%dT%H:%M'), class: 'uppercase w-full rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out' %>
+            </div>
+            <div class="relative mb-4">
+            <button type="submit" class="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">Submit</button>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/app/views/trades/index.html.erb
+++ b/app/views/trades/index.html.erb
@@ -60,6 +60,9 @@
               </td>
               <td class="px-6 py-4 whitespace-no-wrap text-right border-b border-gray-200 text-sm leading-5 font-medium">
                 <a href="<%= trade_path(trade) %>" class="text-indigo-600 hover:text-indigo-900">Show More</a>
+                <% if trade.pending? %>
+                <a href="<%= edit_trade_path(trade) %>" class="text-indigo-600 hover:text-indigo-900">Edit</a>
+                <% end %>
               </td>
             </tr>
           <% end %>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,5 @@
+require 'sidekiq'
+
 sidekiq_config = { url: ENV['REDIS_URL'] }
 
 Sidekiq.configure_server do |config|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
+  mount Sidekiq::Web => '/sidekiq'
+
   get '/profile', to: 'users#show'
   get '/', to: 'home#index', as: :home
 
@@ -21,5 +25,5 @@ Rails.application.routes.draw do
 
   resources :users, only: [:update]
   resources :bank_accounts, only: [:index, :show]
-  resources :trades, only: [:index, :new, :show, :create]
+  resources :trades, except: [:destroy]
 end

--- a/db/migrate/20220324181340_add_job_id_to_trade.rb
+++ b/db/migrate/20220324181340_add_job_id_to_trade.rb
@@ -1,0 +1,5 @@
+class AddJobIdToTrade < ActiveRecord::Migration[5.2]
+  def change
+    add_column :trades, :job_id, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_17_180220) do
+ActiveRecord::Schema.define(version: 2022_03_24_181340) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2022_03_17_180220) do
     t.integer 'timestamp', null: false
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
+    t.string 'job_id'
   end
 
   create_table 'users', force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ x-shared-config: &shared-config
   depends_on:
     - postgres
     - redis
+    - sidekiq
 
 services:
   website:
@@ -46,8 +47,16 @@ services:
     volumes:
       - '.:/website'
   sidekiq:
-    <<: *shared-config
+    image: trader-app_website
     command: bundle exec sidekiq -C config/sidekiq.yml
+    env_file:
+      - ./docker/.env
+    volumes:
+      - '.:/website'
+    depends_on:
+      - redis
+    networks:
+      - gateway
     
   postgres:
     image: postgres:13.4-alpine
@@ -65,6 +74,8 @@ services:
       - "6379:6379"
     volumes:
       - redis:/data
+    networks:
+      - gateway
 volumes:
   base_cache_rails:
   base_gems:

--- a/spec/factories/trades.rb
+++ b/spec/factories/trades.rb
@@ -12,6 +12,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  account_id :integer          not null
+#  job_id     :string
 #
 # Foreign Keys
 #
@@ -26,5 +27,6 @@ FactoryBot.define do
     shares { 1 }
     price { 1.5 }
     timestamp { 10.minutes.ago.to_s(:db) }
+    job_id { nil }
   end
 end

--- a/spec/models/trade_spec.rb
+++ b/spec/models/trade_spec.rb
@@ -12,6 +12,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  account_id :integer          not null
+#  job_id     :string
 #
 # Foreign Keys
 #

--- a/spec/requests/trades_spec.rb
+++ b/spec/requests/trades_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Trades', type: :request do
                      shares: 1,
                      price: 1.5,
                      symbol: 'AAPL',
-                     timestamp: 10.minutes.ago.to_i } } }
+                     timestamp: 10.minutes.ago } } }
 
     before(:each) do
       sign_in user

--- a/spec/requests/trades_spec.rb
+++ b/spec/requests/trades_spec.rb
@@ -107,4 +107,55 @@ RSpec.describe 'Trades', type: :request do
       end
     end
   end
+
+  describe 'GET /trades/:id/edit' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:trade) { FactoryBot.create(:trade, account_id: user.bank_accounts.first.id) }
+    let(:uri) { "/trades/#{trade.id}/edit" }
+
+    before(:each) do
+      sign_in user
+    end
+
+    it 'returns http success' do
+      get uri
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'PATCH /trades/:id' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:trade) { FactoryBot.create(:trade, account_id: user.bank_accounts.first.id) }
+    let(:uri) { "/trades/#{trade.id}" }
+    let(:params) { { trade: { trade_type: 'buy',
+                     account_id: user.bank_accounts.first.id,
+                     shares: 1,
+                     price: 1.5,
+                     symbol: 'AAPL',
+                     timestamp: 10.minutes.ago.to_i } } }
+
+    before(:each) do
+      sign_in user
+    end
+
+    it 'updates the trade' do
+      patch uri, params: params
+      expect(response).to redirect_to(trades_path)
+    end
+
+    context 'with invalid params' do
+      let(:params) { { trade: FactoryBot.build(:trade, timestamp: nil).attributes } }
+
+      it 'does not update the trade' do
+        expect do
+          patch uri, params: params
+        end.not_to change { trade }
+      end
+
+      it 'redirects to trades' do
+        patch uri, params: params
+        expect(response).to redirect_to(trades_path)
+      end
+    end
+  end
 end

--- a/spec/services/trade_creator_spec.rb
+++ b/spec/services/trade_creator_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe TradeCreator, type: :service do
 
       it 'returns trade with errors' do
         trade = described_class.call(trade_params: params).trade
-        expect(trade.errors.full_messages).to eq(['Price must be greater than 0'])
+        expect(trade.errors.full_messages).to eq(['Price must be greater than 0', 'Trade attributes cannot be blank'])
       end
     end
   end

--- a/spec/services/trade_sanitizer_spec.rb
+++ b/spec/services/trade_sanitizer_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe TradeSanitizer, type: :service do
+  context 'when trade.timestamp is a String' do
+    let(:params) { { timestamp: '2018-01-01T00:00:00.000Z' } }
+
+    it 'converts timestamp to integer epoch' do
+      expect(TradeSanitizer.call(trade_params: params).trade_params[:timestamp]).to eq(1514764800)
+    end
+  end
+
+  context 'when trade.symbol is lowercase' do
+    let(:params) { { symbol: 'aapl' } }
+
+    it 'converts symbol to uppercase' do
+      expect(TradeSanitizer.call(trade_params: params).trade_params[:symbol]).to eq('AAPL')
+    end
+  end
+end

--- a/spec/services/trade_updater_spec.rb
+++ b/spec/services/trade_updater_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe TradeUpdater, type: :service do
+  setup do
+    FactoryBot.create(:trade_type, name: 'buy')
+    FactoryBot.create(:trade_type, name: 'sell')
+  end
+
+  describe '#call' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:account_id) { user.bank_account_ids.first }
+
+    context 'when params are valid' do
+      context 'with immediate execution' do
+        let(:trade) { FactoryBot.create(:trade,
+          account_id: account_id,
+          timestamp: 10.minutes.ago.to_i) }
+        let(:params) { { symbol: 'XXL' } }
+
+        it 'updates trade' do
+          service = described_class.call(trade_id: trade.id, trade_params: params)
+          expect(service.trade.symbol).to eq('XXL')
+        end
+
+        it 'updates bank account amount' do
+          result = described_class.call(trade_id: trade.id, trade_params: params).trade
+          amount = result.bank_account.amount - result.total_price
+
+          result.reload
+
+          expect(result.bank_account.amount).to eq(amount)
+          expect(result.state).to eq('done')
+        end
+      end
+
+      context 'with delayed execution' do
+        let(:delayed_trade) { FactoryBot.create(:trade, timestamp: 1.day.from_now.to_i, job_id: 'adasd') }
+        let(:params) { { symbol: 'XXL' } }
+
+        before(:each) do
+          allow_any_instance_of(Sidekiq::ScheduledSet).to receive(:delete_by_jid).and_return(true)
+          allow(ScheduleTradeJob).to receive(:perform_at).and_return('xxxxx')
+        end
+
+        it 'cancel scheduled job' do
+          expect_any_instance_of(Sidekiq::ScheduledSet).to receive(:delete_by_jid).with(delayed_trade.timestamp, 'adasd')
+          described_class.call(trade_id: delayed_trade.id, trade_params: params)
+        end
+
+        it 'schedules trade for processing' do
+          expect(ScheduleTradeJob).to receive(:perform_at).with(delayed_trade.timestamp, delayed_trade.id)
+          result = described_class.call(trade_id: delayed_trade.id, trade_params: params).trade
+          expect(result.job_id).to eq('xxxxx')
+        end
+      end
+    end
+
+    context 'when params are invalid' do
+      let(:trade) { FactoryBot.create(:trade,
+        account_id: account_id,
+        timestamp: 10.minutes.ago.to_i) }
+      let(:params) { { trade_type: 'buy',
+                       shares: 100, price: 0,
+                       symbol: 'AAPL',
+                       account_id: account_id } }
+
+      it 'does not update trade' do
+        service = described_class.call(trade_id: trade.id, trade_params: params)
+        expect(service).to be_failure
+      end
+
+      it 'returns trade with errors' do
+        result = described_class.call(trade_id: trade.id, trade_params: params).trade
+        expect(result.errors.full_messages).to eq(['Price must be greater than 0'])
+      end
+    end
+  end
+end

--- a/spec/sidekiq/schedule_trade_job_spec.rb
+++ b/spec/sidekiq/schedule_trade_job_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+RSpec.describe ScheduleTradeJob, type: :job do
+  setup do
+    FactoryBot.create(:trade_type, name: 'buy')
+    FactoryBot.create(:trade_type, name: 'sell')
+  end
+
+  let(:user) { FactoryBot.create(:user) }
+
+  describe '#perform' do
+    let(:account_ids) { user.bank_account_ids }
+    let(:trade) { FactoryBot.create(:trade, account_id: account_ids.first) }
+
+    it 'process a trade' do
+      expect do
+        ScheduleTradeJob.perform_at(Time.now.to_i, trade.id)
+      end.to change(trade, :state).from('pending').to('done')
+    end
+  end
+end

--- a/spec/sidekiq/schedule_trade_job_spec.rb
+++ b/spec/sidekiq/schedule_trade_job_spec.rb
@@ -12,9 +12,8 @@ RSpec.describe ScheduleTradeJob, type: :job do
     let(:trade) { FactoryBot.create(:trade, account_id: account_ids.first) }
 
     it 'process a trade' do
-      expect do
-        ScheduleTradeJob.perform_at(Time.now.to_i, trade.id)
-      end.to change(trade, :state).from('pending').to('done')
+      ScheduleTradeJob.perform_at(Time.now.to_i, trade.id)
+      expect(ScheduleTradeJob).to have_enqueued_sidekiq_job(trade.id)
     end
   end
 end

--- a/spec/support/sidekiq_helpers.rb
+++ b/spec/support/sidekiq_helpers.rb
@@ -1,0 +1,10 @@
+RSpec::Sidekiq.configure do |config|
+  # Clears all job queues before each example
+  config.clear_all_enqueued_jobs = true # default => true
+
+  # Whether to use terminal colours when outputting messages
+  config.enable_terminal_colours = true # default => true
+
+  # Warn when jobs are not enqueued to Redis but to a job array
+  config.warn_when_jobs_not_processed_by_sidekiq = true # default => true
+end


### PR DESCRIPTION
Adds `trade/edit` when the trade is still pending.

<img width="1766" alt="image" src="https://user-images.githubusercontent.com/6758195/160149075-296b07b3-af21-4d4e-9ef0-e407d5575248.png">


When the trade is pending and the user updates:
  -> The app cancel the scheduled job if the trade was scheduled (to make sure we don't have hanging trades enqueued)
  ->  Updates the trade record with new values
  ->  Schedule again the trade if the new timestamp has changed for a date in the future